### PR TITLE
Fixing class name in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ composer require cache/psr-6-doctrine-bridge
 use DoctrineCacheBridge\DoctrineCacheBridge;
 
 // Assuming $pool is an instance of \Psr\Cache\CacheItemPoolInterface
-$cacheProvider = new DoctrineBridge($pool);
+$cacheProvider = new DoctrineCacheBridge($pool);
 
 $cacheProvider->contains($key);
 $cacheProvider->fetch($key);


### PR DESCRIPTION
A very small fix in the doc.

By the way, I just wrote a ["universal service provider"](http://github.com/container-interop/service-provider) for this package here: https://github.com/thecodingmachine/psr-6-doctrine-bridge-universal-module (if you are interested)
